### PR TITLE
Make Option.to_seq() return a Seq and add create classmethods to Seq

### DIFF
--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -47,6 +47,14 @@ class Seq(Iterable[TSource]):
     def __init__(self, iterable: Iterable[TSource] = []) -> None:
         self._value = iterable
 
+    @classmethod
+    def of(cls, *args: TSource) -> "Seq[TSource]":
+        return cls(args)
+
+    @classmethod
+    def of_iterable(cls, source: Iterable[TSource]) -> "Seq[TSource]":
+        return cls(source)
+
     def filter(self, predicate: Callable[[TSource], bool]) -> "Seq[TSource]":
         return Seq(filter(predicate)(self))
 

--- a/expression/core/aiotools.py
+++ b/expression/core/aiotools.py
@@ -32,7 +32,7 @@ def from_continuations(callback: Callbacks[TSource]) -> Awaitable[TSource]:
         An asynchronous computation that provides the callback with the
         current continuations.
     """
-    future: Future[TSource] = asyncio.Future()
+    future: "Future[TSource]" = asyncio.Future()
 
     def done(value: TSource) -> None:
         future.set_result(value)


### PR DESCRIPTION
`Option.to_seq() -> Seq` Requires some `if TYPE_CHECKING` and deferred import hacks to avoid circular dependencies. What do you think?